### PR TITLE
Get instance credentials working with HTTP.jl 0.6

### DIFF
--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -170,7 +170,7 @@ function ec2_metadata(key)
 
     @assert localhost_is_ec2()
 
-    String(take!(http_get("http://169.254.169.254/latest/meta-data/$key")))
+    String(http_get("http://169.254.169.254/latest/meta-data/$key").body)
 end
 
 
@@ -216,7 +216,7 @@ function ecs_instance_credentials()
 
     uri = ENV["AWS_CONTAINER_CREDENTIALS_RELATIVE_URI"]
 
-    new_creds = JSON.parse(String(take!(http_get("http://169.254.170.2$uri"))))
+    new_creds = JSON.parse(String(http_get("http://169.254.170.2$uri").body))
 
     if debug_level > 0
         print("Loading AWSCredentials from ECS metadata... ")

--- a/src/http.jl
+++ b/src/http.jl
@@ -56,7 +56,7 @@ end
 
 function http_get(url::String)
 
-    host = HTTP.URIs.hostname(HTTP.URI(url))
+    host = HTTP.URI(url).host
 
     http_request(@SymDict(verb = "GET",
                           url = url,


### PR DESCRIPTION
These appear to work in practice but please let me know if there are any semantic differences I'm not aware of.