### PR TITLE
WIP: Updates for Julia 0.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,6 @@ os:
   - linux
   - osx
 julia:
-  - 0.6
   - 0.7
   - nightly
 notifications:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ os:
   - osx
 julia:
   - 0.6
+  - 0.7
+  - nightly
 notifications:
   email: false
 env:

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,8 +1,7 @@
-julia 0.6
-Compat 0.65.0
-Retry 0.2.0
+julia 0.7.0-beta
+Retry 0.3.0
 SymDict 0.1.2
-XMLDict 0.1.3
+XMLDict 0.2.0
 JSON 0.5
 IniFile
 HTTP 0.6.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -2,7 +2,7 @@ julia 0.6
 Compat 0.65.0
 Retry 0.2.0
 SymDict 0.1.2
-EzXML
+XMLDict 0.1.3
 JSON 0.5
 IniFile
 HTTP 0.6.3

--- a/REQUIRE
+++ b/REQUIRE
@@ -1,7 +1,8 @@
 julia 0.6
+Compat 0.65.0
 Retry 0.2.0
 SymDict 0.1.2
-XMLDict 0.1.3
+EzXML
 JSON 0.5
 IniFile
 HTTP 0.6.3

--- a/src/AWSAPI.jl
+++ b/src/AWSAPI.jl
@@ -181,7 +181,7 @@ function service_shape_doc(service, name, pad="", stack=[])
 end
 
 
-function pretty(d::Associative, dict = "Dict()", pad="")
+function pretty(d::AbstractDict, dict = "Dict()", pad="")
     dict[1:end-1] * "\n" *
     join([string(pad, "    \"", k, "\" => ", pretty(v, dict, pad * "    "))
           for (k, v) in d], ",\n") *

--- a/src/AWSAPI.jl
+++ b/src/AWSAPI.jl
@@ -27,8 +27,7 @@ sdk_module_name(service_name) = "AWSSDK.$(service_name)"
 
 Transform CamelCase to lowercase_with_underscores.
 """
-
-uncamel(s) = lowercase(replace(s, r"([a-z])([A-Z])", s"\1_\2"))
+uncamel(s) = lowercase(replace(s, r"([a-z])([A-Z])" => s"\1_\2"))
 
 
 """
@@ -36,10 +35,7 @@ uncamel(s) = lowercase(replace(s, r"([a-z])([A-Z])", s"\1_\2"))
 
 Join `words` with commas and "or". e.g. "one, two or three".
 """
-
-orjoin(words) = isempty(words) ? "" :
-                length(words) == 1 ? words[1] :
-                "$(join(words[1:end-1], ", ")) or $(words[end])"
+orjoin(words) = join(words, ", ", " or ")
 
 
 function is_simple_post_service(service)
@@ -47,7 +43,7 @@ function is_simple_post_service(service)
         &&  service["metadata"]["endpointPrefix"] != "importexport")
 end
 
-is_rest_service(service) = ismatch(r"^rest", service["metadata"]["protocol"])
+is_rest_service(service) = occursin(r"^rest", service["metadata"]["protocol"])
 
 
 function member_name(service, name, info)
@@ -202,7 +198,7 @@ function pretty(s::String, args...)
     s = replace(s, "\$", "\\\$")
 
     # Work around for https://github.com/JuliaLang/julia/pull/22800
-    s = replace(s, r"([^\\])\\([^ntrebfva\\'\"$`0-9])", s"\1\\\\\2")
+    s = replace(s, r"([^\\])\\([^ntrebfva\\'\"$`0-9])" => s"\1\\\\\2")
 
     return "\"$s\""
 end
@@ -297,7 +293,7 @@ function service_operation(service, operation, info)
         sig4 = ""
     end
 
-    @assert !ismatch(r"[{][^{}]+[}]", resource) || is_rest_service(service)
+    @assert !occursin(r"[{][^{}]+[}]", resource) || is_rest_service(service)
 
     m = service["metadata"]["juliaModule"]
 

--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -14,21 +14,14 @@ module AWSCore
 export AWSException, AWSConfig, AWSRequest,
        aws_config, default_aws_config
 
-using Compat
-using Compat.Base64
-using Compat.Dates
-using Compat.Sockets
+using Base64
+using Dates
+using Sockets
 using Retry
 using SymDict
 using XMLDict
 using HTTP
 using DataStructures: OrderedDict
-
-if isdefined(Sockets, :DNSError) # DNSError was inadvertently omitted in Compat.Sockets
-    import Sockets: DNSError
-else
-    import Base: DNSError
-end
 
 
 """
@@ -406,7 +399,7 @@ function do_request(r::AWSRequest)
 
         # Load local system credentials if needed...
         if r[:creds].token == "ExpiredToken"
-            copy!(r[:creds], AWSCredentials())
+            copyto!(r[:creds], AWSCredentials())
         end
 
         # Use credentials to sign request...

--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -17,7 +17,7 @@ export AWSException, AWSConfig, AWSRequest,
 using Compat
 using Retry
 using SymDict
-using EzXML
+using XMLDict
 using HTTP
 using DataStructures: OrderedDict
 
@@ -464,7 +464,7 @@ function do_request(r::AWSRequest)
     end
 
     if occursin(r"/xml", mime)
-        return parsexml(String(response.body))
+        return parse_xml(String(response.body))
     end
 
     if occursin(r"/x-amz-json-1.[01]$", mime)

--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -112,7 +112,7 @@ function aws_config(;creds=AWSCredentials(),
 end
 
 
-global _default_aws_config = Nullable{AWSConfig}()
+global _default_aws_config = nothing # Union{AWSConfig,Nothing}
 
 
 """
@@ -121,10 +121,10 @@ obtained by calling [`aws_config`](@ref) with no optional arguments.
 """
 function default_aws_config()
     global _default_aws_config
-    if isnull(_default_aws_config)
-        _default_aws_config = Nullable(aws_config())
+    if _default_aws_config === nothing
+        _default_aws_config = aws_config()
     end
-    return get(_default_aws_config)
+    return _default_aws_config
 end
 
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -30,7 +30,6 @@ The `user_arn` and `account_number` fields are used to cache the result of the [
 The `AWSCredentials()` constructor tries to load local Credentials from
 environment variables, `~/.aws/credentials`, `~/.aws/config` or EC2 instance credentials.
 """
-
 mutable struct AWSCredentials
     access_key_id::String
     secret_key::String
@@ -56,8 +55,8 @@ function Base.show(io::IO,c::AWSCredentials)
                        ")")
 end
 
-function Base.copy!(dest::AWSCredentials, src::AWSCredentials)
-    for f in fieldnames(dest)
+function Compat.copyto!(dest::AWSCredentials, src::AWSCredentials)
+    for f in fieldnames(typeof(dest))
         setfield!(dest, f, getfield(src, f))
     end
 end
@@ -97,14 +96,12 @@ end
 """
 Is Julia running in an AWS Lambda sandbox?
 """
-
 localhost_is_lambda() = haskey(ENV, "LAMBDA_TASK_ROOT")
 
 
 """
 Is Julia running on an EC2 virtual machine?
 """
-
 function localhost_is_ec2()
 
     if localhost_is_lambda()
@@ -143,7 +140,6 @@ for configrued user.
 
 e.g. `"arn:aws:iam::account-ID-without-hyphens:user/Bob"`
 """
-
 function aws_user_arn(aws::AWSConfig)
 
     creds = aws[:creds]
@@ -164,7 +160,6 @@ end
 
 12-digit [AWS Account Number](http://docs.aws.amazon.com/general/latest/gr/acct-identifiers.html).
 """
-
 function aws_account_number(aws::AWSConfig)
     creds = aws[:creds]
     if creds.account_number == ""
@@ -181,7 +176,6 @@ Fetch [EC2 meta-data]
 (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html)
 for `key`.
 """
-
 function ec2_metadata(key)
 
     @assert localhost_maybe_ec2()
@@ -197,7 +191,6 @@ Load [Instance Profile Credentials]
 (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/iam-roles-for-amazon-ec2.html#instance-metadata-security-credentials)
 for EC2 virtual machine.
 """
-
 function ec2_instance_credentials()
 
     @assert localhost_maybe_ec2()
@@ -224,7 +217,6 @@ end
 Load [ECS Task Credentials]
 (http://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html)
 """
-
 function ecs_instance_credentials()
 
     @assert haskey(ENV, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
@@ -250,7 +242,6 @@ Load Credentials from [environment variables]
 `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` etc.
 (e.g. in Lambda sandbox).
 """
-
 function env_instance_credentials()
 
     if debug_level > 0

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -121,6 +121,7 @@ function localhost_is_ec2()
             if String(read("/sys/devices/virtual/dmi/id/product_uuid")) == "EC2"
                 return true
             end
+        catch
         end
     end
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -55,12 +55,13 @@ function Base.show(io::IO,c::AWSCredentials)
                        ")")
 end
 
-function Compat.copyto!(dest::AWSCredentials, src::AWSCredentials)
+function Base.copyto!(dest::AWSCredentials, src::AWSCredentials)
     for f in fieldnames(typeof(dest))
         setfield!(dest, f, getfield(src, f))
     end
 end
-
+import Base: copy!
+Base.@deprecate copy!(dest::AWSCredentials, src::AWSCredentials) copyto!(dest, src)
 
 function AWSCredentials()
 

--- a/src/AWSException.jl
+++ b/src/AWSException.jl
@@ -31,13 +31,13 @@ function AWSException(e::HTTP.StatusError)
     info = Dict()
 
     # Extract API error code from Lambda-style JSON error message...
-    if ismatch(r"json$", content_type(e))
+    if occursin(r"json$", content_type(e))
         info = JSON.parse(http_message(e))
         message = get(info, "message", message)
     end
 
     # Extract API error code from JSON error message...
-    if ismatch(r"^application/x-amz-json-1.[01]$", content_type(e))
+    if occursin(r"^application/x-amz-json-1.[01]$", content_type(e))
         info = JSON.parse(http_message(e))
         if haskey(info, "__type")
             code = split(info["__type"], "#")[end]
@@ -47,7 +47,7 @@ function AWSException(e::HTTP.StatusError)
     # Extract API error code from XML error message...
     if (content_type(e) in ["", "application/xml", "text/xml"]
     &&  length(http_message(e)) > 0)
-        info = parse_xml(http_message(e))
+        info = parsexml(http_message(e))
     end
 
     info = get(info, "Errors", info)

--- a/src/AWSException.jl
+++ b/src/AWSException.jl
@@ -47,7 +47,7 @@ function AWSException(e::HTTP.StatusError)
     # Extract API error code from XML error message...
     if (content_type(e) in ["", "application/xml", "text/xml"]
     &&  length(http_message(e)) > 0)
-        info = parsexml(http_message(e))
+        info = parse_xml(http_message(e))
     end
 
     info = get(info, "Errors", info)

--- a/src/AWSMetadata.jl
+++ b/src/AWSMetadata.jl
@@ -37,7 +37,7 @@ Cache for files downloaded from the AWS JavaScript SDK on GitHub.
 
 cachedir() = joinpath(@__DIR__, "aws-sdk-js")
 cachehas(file) = isfile(joinpath(cachedir(), file))
-cacheget(file) = readstring(joinpath(cachedir(), file))
+cacheget(file) = read(joinpath(cachedir(), file), String)
 
 function cacheput(file, data)
     p = joinpath(cachedir(), file)
@@ -51,7 +51,6 @@ end
 
 List contents of `dirname` in the AWS JavaScript SDK on GitHub.
 """
-
 function aws_sdk_js_ls(dirname)
 
     cachename = dirname * ".contents"
@@ -75,7 +74,6 @@ end
 
 Get `filename` from the AWS JavaScript SDK on GitHub.
 """
-
 function aws_sdk_js(filename)
 
     if cachehas(filename * ".404")
@@ -111,7 +109,6 @@ _service_list = OrderedDict()
 
 Dict of services supported by the AWS JavaScript SDK.
 """
-
 function service_list()
 
     global _service_list
@@ -157,7 +154,6 @@ Get `service-2.json` file for `service`.
 
 e.g.  `service_definition(services()["SQS"])`
 """
-
 function service_definition(service)
 
     # Fetch ".normal.json" service definition from AWS JavaScript SDK...
@@ -219,7 +215,6 @@ end
 
 Print summary information about available services.
 """
-
 function service_summary()
 
     services = service_list()

--- a/src/HTML2MD.jl
+++ b/src/HTML2MD.jl
@@ -20,12 +20,6 @@ const tcp_port = 34562
 
 server_process = nothing
 
-if VERSION >= v"0.7.0-DEV.4445"
-    _runasync(cmd) = run(cmd, wait=false)
-else
-    _runasync(cmd) = spawn(cmd)
-end
-
 function start_node_server()
 
     global server_process
@@ -36,7 +30,7 @@ function start_node_server()
         run(setenv(`$(npm_cmd()) install to-markdown`, dir=@__DIR__))
     end
 
-    server_process = _runasync(`$(nodejs_cmd()) -e """
+    server_process = run(`$(nodejs_cmd()) -e """
         const http = require('http')  
         const port = $tcp_port
         const h2m = require('to-markdown')
@@ -85,7 +79,7 @@ function start_node_server()
             return console.log('HTML2MD Error:', err)
           }
         })
-    """`)
+    """`, wait=false)
 
     atexit(() -> kill(server_process))
 

--- a/src/HTML2MD.jl
+++ b/src/HTML2MD.jl
@@ -30,7 +30,7 @@ function start_node_server()
         run(setenv(`$(npm_cmd()) install to-markdown`, dir=@__DIR__))
     end
 
-    server_process = spawn(`$(nodejs_cmd()) -e """
+    server_process = run(`$(nodejs_cmd()) -e """
         const http = require('http')  
         const port = $tcp_port
         const h2m = require('to-markdown')
@@ -79,7 +79,7 @@ function start_node_server()
             return console.log('HTML2MD Error:', err)
           }
         })
-    """`)
+    """`, wait=false)
 
     atexit(() -> kill(server_process))
 
@@ -96,14 +96,14 @@ function html2md(html)
         start_node_server()
     end
 
-    html = replace(html, "\\", "\\\\")
-    html = replace(html, "\$", "\\\$")
-    html = replace(html, "\"\"\"", "\\\"\\\"\\\"")
+    html = replace(html, "\\" => "\\\\")
+    html = replace(html, "\$" => "\\\$")
+    html = replace(html, "\"\"\"" => "\\\"\\\"\\\"")
 
     md = String(post(URI("http://localhost:$tcp_port"), html).data)
 
     # Work around for https://github.com/domchristie/to-markdown/issues/181
-    md = replace(md, r"([0-9])\\[.]", s"\1.")
+    md = replace(md, r"([0-9])\\[.]" => s"\1.")
 
     return md
 end

--- a/src/HTML2MD.jl
+++ b/src/HTML2MD.jl
@@ -20,6 +20,12 @@ const tcp_port = 34562
 
 server_process = nothing
 
+if VERSION >= v"0.7.0-DEV.4445"
+    _runasync(cmd) = run(cmd, wait=false)
+else
+    _runasync(cmd) = spawn(cmd)
+end
+
 function start_node_server()
 
     global server_process
@@ -30,7 +36,7 @@ function start_node_server()
         run(setenv(`$(npm_cmd()) install to-markdown`, dir=@__DIR__))
     end
 
-    server_process = run(`$(nodejs_cmd()) -e """
+    server_process = _runasync(`$(nodejs_cmd()) -e """
         const http = require('http')  
         const port = $tcp_port
         const h2m = require('to-markdown')
@@ -79,7 +85,7 @@ function start_node_server()
             return console.log('HTML2MD Error:', err)
           }
         })
-    """`, wait=false)
+    """`)
 
     atexit(() -> kill(server_process))
 

--- a/src/http.jl
+++ b/src/http.jl
@@ -49,7 +49,7 @@ function http_request(request::AWSRequest)
 
     catch e
 
-        @delay_retry if isa(e, DNSError) ||
+        @delay_retry if isa(e, Sockets.DNSError) ||
                         isa(e, HTTP.ParseError) ||
                         isa(e, HTTP.IOError) ||
                         #isa(e, EOFError) || FIXME needed ?

--- a/src/http.jl
+++ b/src/http.jl
@@ -49,7 +49,7 @@ function http_request(request::AWSRequest)
 
     catch e
 
-        @delay_retry if isa(e, Base.DNSError) ||
+        @delay_retry if isa(e, DNSError) ||
                         isa(e, HTTP.ParseError) ||
                         isa(e, HTTP.IOError) ||
                         #isa(e, EOFError) || FIXME needed ?

--- a/src/names.jl
+++ b/src/names.jl
@@ -20,7 +20,6 @@ export arn, is_arn,
 
 Generate an [Amazon Resource Name](http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html) for `service` and `resource`.
 """
-
 function arn(service, resource,
              region=get(default_aws_config(), :region, ""),
              account=aws_account_number(default_aws_config()))
@@ -51,7 +50,6 @@ end
 
 Extract service name from `arn`.
 """
-
 arn_service(arn) = split(arn, ":")[3]
 
 
@@ -60,7 +58,6 @@ arn_service(arn) = split(arn, ":")[3]
 
 Extract region name from `arn`.
 """
-
 arn_region(arn) = split(arn, ":")[4]
 
 
@@ -69,7 +66,6 @@ arn_region(arn) = split(arn, ":")[4]
 
 Extract account number from `arn`.
 """
-
 arn_account(arn) = split(arn, ":")[5]
 
 
@@ -78,7 +74,6 @@ arn_account(arn) = split(arn, ":")[5]
 
 Extract resource name from `arn`.
 """
-
 arn_resource(arn) = split(arn, ":")[6]
 
 
@@ -114,8 +109,8 @@ function is_arn(arn)
     return length(v) >= 6 && all(v[1:5] .|> p)
 end
 
-arn_match(s, n, p) = ismatch(p, s) ||
-                     (debug_level == 0 || warn("Bad ARN $n: \"$s\""); false)
+arn_match(s, n, p) = occursin(p, s) ||
+                     (debug_level == 0 || Compat.@warn("Bad ARN $n: \"$s\""); false)
 
 is_arn_prefix(s) = arn_match(s, "prefix",   r"^arn$")
 is_partition(s)  = arn_match(s, "partiton", r"^aws[a-z-]*$")

--- a/src/names.jl
+++ b/src/names.jl
@@ -109,7 +109,7 @@ function is_arn(arn)
 end
 
 arn_match(s, n, p) = occursin(p, s) ||
-                     (debug_level == 0 || Compat.@warn("Bad ARN $n: \"$s\""); false)
+                     (debug_level == 0 || @warn("Bad ARN $n: \"$s\""); false)
 
 is_arn_prefix(s) = arn_match(s, "prefix",   r"^arn$")
 is_partition(s)  = arn_match(s, "partiton", r"^aws[a-z-]*$")

--- a/src/names.jl
+++ b/src/names.jl
@@ -100,7 +100,6 @@ arn_iam_name(arn) = split(arn_resource(arn), "/")[end]
 Is `arn` in the [correct format]?
 (http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html)
 """
-
 function is_arn(arn)
 
     v = split(arn, ":")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,9 +4,8 @@
 # Copyright OC Technology Pty Ltd 2014 - All rights reserved
 #==============================================================================#
 
-using Compat
-using Compat.Test
-using Compat.Dates
+using Test
+using Dates
 using AWSCore
 using SymDict
 using Retry

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -4,12 +4,12 @@
 # Copyright OC Technology Pty Ltd 2014 - All rights reserved
 #==============================================================================#
 
-
-using Base.Test
+using Compat
+using Compat.Test
 using AWSCore
 using SymDict
 using Retry
-using XMLDict
+using EzXML
 
 using AWSCore: service_query
 
@@ -23,7 +23,7 @@ aws = aws_config()
 @testset "Load Credentials" begin
     user = aws_user_arn(aws)
 
-    @test ismatch(r"^arn:aws:iam::[0-9]+:[^:]+$", user)
+    @test occursin(r"^arn:aws:iam::[0-9]+:[^:]+$", user)
 
     println("Authenticated as: $user")
 
@@ -184,7 +184,7 @@ end
 end
 
 @testset "XML Parsing" begin
-    XML(x)=parse_xml(x)
+    XML(x) = parsexml(x)
 
     xml = """
     <CreateQueueResponse>

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -6,6 +6,7 @@
 
 using Compat
 using Compat.Test
+using Compat.Dates
 using AWSCore
 using SymDict
 using Retry

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,7 +9,7 @@ using Compat.Test
 using AWSCore
 using SymDict
 using Retry
-using EzXML
+using XMLDict
 
 using AWSCore: service_query
 
@@ -184,7 +184,7 @@ end
 end
 
 @testset "XML Parsing" begin
-    XML(x) = parsexml(x)
+    XML(x)=parse_xml(x)
 
     xml = """
     <CreateQueueResponse>


### PR DESCRIPTION
In updating to 0.7, this also replaces the dependency on XMLDict with one on EzXML, as LightXML, upon which XMLDict is based, does not work on 0.7 and seems to be largely unmaintained. EzXML provides a `Dict`-like interface for XML documents that should work in most cases where XMLDict is currently used.