### PR TITLE
added profile argument to `aws_config`

### DIFF
--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -73,6 +73,7 @@ The `aws_config` function provides a simple way to creates an
 >aws = aws_config()
 >aws = aws_config(creds = my_credentials)
 >aws = aws_config(region = "ap-southeast-2")
+>aws = aws_config(profile = "profile-name")
 ```
 
 By default, the `aws_config` attempts to load AWS credentials from:
@@ -91,8 +92,9 @@ aws_access_key_id = AKIAXXXXXXXXXXXXXXXX
 aws_secret_access_key = XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX
 ```
 
-If your `~/.aws/credentials` file contains multiple profiles you can
-select a profile by setting the `AWS_PROFILE` environment variable.
+If your `~/.aws/credentials` file contains multiple profiles you can pass the
+profile name as a string to the `profile` keyword argument (`nothing` by
+default) or select a profile by setting the `AWS_PROFILE` environment variable.
 
 `aws_config` understands the following [AWS CLI environment
 variables](http://docs.aws.amazon.com/cli/latest/userguide/cli-chap-getting-started.html#cli-environment):

--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -109,7 +109,8 @@ aws = aws_config(creds = AWSCredentials("AKIAXXXXXXXXXXXXXXXX",
 ```
 
 """
-function aws_config(;creds=AWSCredentials(),
+function aws_config(;profile=nothing,
+                     creds=AWSCredentials(profile=profile),
                      region=get(ENV, "AWS_DEFAULT_REGION", "us-east-1"),
                      args...)
     @SymDict(creds, region, args...)

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -29,6 +29,7 @@ The `user_arn` and `account_number` fields are used to cache the result of the [
 
 The `AWSCredentials()` constructor tries to load local Credentials from
 environment variables, `~/.aws/credentials`, `~/.aws/config` or EC2 instance credentials.
+To specify the profile to use from `~/.aws/credentials`, do, for example, `AWSCredentials(profile="profile-name")`.
 """
 mutable struct AWSCredentials
     access_key_id::String

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -63,7 +63,7 @@ end
 import Base: copy!
 Base.@deprecate copy!(dest::AWSCredentials, src::AWSCredentials) copyto!(dest, src)
 
-function AWSCredentials()
+function AWSCredentials(;profile=nothing)
 
     if haskey(ENV, "AWS_ACCESS_KEY_ID")
 
@@ -71,7 +71,7 @@ function AWSCredentials()
 
     elseif isfile(dot_aws_credentials_file()) || isfile(dot_aws_config_file())
 
-        creds = dot_aws_credentials()
+        creds = dot_aws_credentials(profile)
 
     elseif haskey(ENV, "AWS_CONTAINER_CREDENTIALS_RELATIVE_URI")
 


### PR DESCRIPTION
and `AWSCredentials`.

This allows users to select a profile without relying on environment variables.

EDIT BY @iamed2: Closes https://github.com/JuliaCloud/AWSCore.jl/issues/37