### PR TITLE
cleaned up exception handling slightly

### DIFF
--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -5,9 +5,6 @@
 #==============================================================================#
 
 
-__precompile__()
-
-
 module AWSCore
 
 
@@ -424,7 +421,7 @@ function do_request(r::AWSRequest)
         end
 
     catch e
-        e = AWSException(e)
+        e = aws_exception(e)
 
         # Handle expired signature...
         @retry if :message in fieldnames(typeof(e)) &&

--- a/src/AWSException.jl
+++ b/src/AWSException.jl
@@ -56,7 +56,8 @@ function AWSException(e::HTTP.StatusError)
 end
 
 
-AWSException(e) = e
+aws_exception(e::Exception) = rethrow(e)
+aws_exception(e::HTTP.StatusError) = AWSException(e)
 
 
 #==============================================================================#

--- a/src/AWSException.jl
+++ b/src/AWSException.jl
@@ -56,6 +56,16 @@ function AWSException(e::HTTP.StatusError)
 end
 
 
+"""
+    aws_exception(e::Exception)
+
+Attempts to create an `AWSException` object out of the provided `Exception`.
+
+If this cannot be done, the error will be immediately rethrown.
+
+This should only be used within `catch` clauses, as provided errors may be rethrown rather
+than thrown.
+"""
 aws_exception(e::Exception) = rethrow(e)
 aws_exception(e::HTTP.StatusError) = AWSException(e)
 


### PR DESCRIPTION
This fixes #50 as well as cleaning up the exception handling a bit.  So the issue is that `AWSException` had a constructor that was just the identity, and that this was being called on `ErrorException`.  It then got to a line where it tried to access a field of `ErrorException` and crashed during error handling.

I've done a couple of things here to try to improve the situation.  First, I've removed the identity constructor of `AWSException`.  This constructor seems very confusing since not only might it return an unexpected `Exception` type, it can in fact return literally anything at all.

I have replaced this constructor with a new `aws_exception` function (non necessarily the best name).  The idea is that this function should construct an `AWSException` on any exception which `AWSException` can wrap (at the moment, only `HTTP.StatusError`) but if passed an exception which it does *not* know how to handle (as was happening in #50) it will immediately rethrow the error.  This way the body of `do_request` is free to implement handling of `AWSException` knowing that all other exceptions will be safely thrown.  It's possible that more methods should be added to this, but there were none that I could see for right now (certainly more can be added in the future).

I also took the liberty of removing the `__precompile__` call which is not necessary in Julia 1.0.

I realize that this was a somewhat aggressive fix to this small issue, but I'll hope you'll agree with me that the identity constructor for `AWSException` was confusing and likely would have led to more errors in the future.  Thanks!