### PR TITLE
Make bors delete merged branches

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,3 +1,4 @@
 status = [
   "continuous-integration/travis-ci/push"
 ]
+delete-merged-branches = true


### PR DESCRIPTION
It probably can't delete merged branches from forks, like for example the branch this commit is from, but it will help for cleanup otherwise.