### PR TITLE
Bugfix and testing upgrade for renewable AWSCredentials

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,10 @@ julia:
 matrix:
   allow_failures:
     - julia: nightly
+    - julia: 1.0
+      stage: "Verify AWSS3"
+    - julia: 1.0
+      stage: "Verify AWSSQS"
 branches:
   only:
     - master

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,16 @@ env:
     - secure: Lrh6AxUp1yFdsB1XlvNHFk+5pOMGQR8bJadUtnqXsuk97ieINI5w/da6wBPIH4WkZBGpQr+uJLe10PTxDcaNeZOC1LcuSK+v5J88pSiFYi10BggYWC2Kb2XEVBjd9BHi/RxAkiHXziBEaqpuX2WcwY2hgAOU+rpt3M9U9SxDITXNG68PpVVqDJ7GSZvZeJZnLrjTPKLlFR8EkqrE23bTaGvzqn50fwk7U3n0F04slkmg2ORScWkgBSFmaATBbiSU9Pz7bB4KuGarNC0Q0eTeoZcThRVYVwse3oLnYLMXkUuIDF5QwDfA5HCC4ad5yXdVenwHZSPS/sSnRM+fVAwkU8CL7hFC9zX2X/fBExWet0LufaCh4L6pax3dKV2m6q3Uq9M1z8X33ry2xqS96rpdD4bo+FxYrzjyAotn46w4fPE7yb3YZgf+dbHTDfVjiPH70hIKUhKiyzyKMTwdT63WNIy1/qbREge4jPVXgnIM3/jAu0THf74cT+RwN4xQnt7a50Yn2c/I+37kO2B+4qkyh4p75eIfPXqak1vdDc9tUqxZa7lPdIkofT3jp7TaJ+4/OLf2OrpA2XFjx20el4/TdB9TiJtGv0qTrujY4wh5BALxGVoSEihj3ahkqV/FQ6RyWJsMggd3yoaING61nCkDXUvLk/44yzeYavNrUaMzWpc=
 jobs:
   include:
+    - stage: "Verify AWSS3"
+      julia: 1.0
+      os: linux
+      script:
+        - julia -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.add("AWSS3"); Pkg.test("AWSS3")'
+    - stage: "Verify AWSSQS"
+      julia: 1.0
+      os: linux
+      script:
+        - julia -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.add("AWSSQS"); Pkg.test("AWSSQS")'
     - stage: "Documentation"
       julia: 1.0
       os: linux

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,12 +29,12 @@ jobs:
       julia: 1.0
       os: linux
       script:
-        - julia -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.add("AWSS3"); Pkg.test("AWSS3")'
+        - julia --project=tmps3 -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.add("AWSS3"); Pkg.test("AWSS3")'
     - stage: "Verify AWSSQS"
       julia: 1.0
       os: linux
       script:
-        - julia -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.add("AWSSQS"); Pkg.test("AWSSQS")'
+        - julia --project=tmpsqs -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.add("AWSSQS"); Pkg.test("AWSSQS")'
     - stage: "Documentation"
       julia: 1.0
       os: linux

--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -109,7 +109,7 @@ aws = aws_config(creds = AWSCredentials("AKIAXXXXXXXXXXXXXXXX",
 
 """
 function aws_config(;profile=nothing,
-                     creds=RenewableAWSCredentials(profile=profile),
+                     creds=AWSCredentials(profile=profile),
                      region=get(ENV, "AWS_DEFAULT_REGION", "us-east-1"),
                      args...)
     @SymDict(creds, region, args...)
@@ -432,7 +432,7 @@ function do_request(r::AWSRequest)
                                "RequestExpired")
 
             # Reload local system credentials if needed...
-            get_credentials(r[:creds], force_refresh=true)
+            check_credentials(r[:creds], force_refresh=true)
 
         end
 

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -270,11 +270,13 @@ function ec2_instance_credentials()
         print("Loading AWSCredentials from EC2 metadata... ")
     end
 
+    expiry = DateTime(strip(new_creds["Expiration"], 'Z'))
+
     AWSCredentials(new_creds["AccessKeyId"],
                    new_creds["SecretAccessKey"],
                    new_creds["Token"],
                    info["InstanceProfileArn"];
-                   expiry = unix2datetime(new_creds["Expiration"]))
+                   expiry = expiry)
 end
 
 
@@ -295,11 +297,13 @@ function ecs_instance_credentials()
         print("Loading AWSCredentials from ECS metadata... ")
     end
 
+    expiry = DateTime(strip(new_creds["Expiration"], 'Z'))
+
     AWSCredentials(new_creds["AccessKeyId"],
                    new_creds["SecretAccessKey"],
                    new_creds["Token"],
                    new_creds["RoleArn"];
-                   expiry = unix2datetime(new_creds["Expiration"]))
+                   expiry = expiry)
 end
 
 

--- a/src/sign.jl
+++ b/src/sign.jl
@@ -34,7 +34,7 @@ function sign_aws2!(r::AWSRequest, t)
     r[:headers]["Content-Type"] =
         "application/x-www-form-urlencoded; charset=utf-8"
 
-    creds = get_credentials(r[:creds])
+    creds = check_credentials(r[:creds])
     query["AWSAccessKeyId"] = creds.access_key_id
     query["Expires"] = Dates.format(t + Dates.Second(120),
                                    dateformat"yyyy-mm-dd\THH:MM:SS\Z")
@@ -70,7 +70,7 @@ function sign_aws4!(r::AWSRequest, t)
     # Authentication scope...
     scope = [date, r[:region], r[:service], "aws4_request"]
 
-    creds = get_credentials(r[:creds])
+    creds = check_credentials(r[:creds])
     # Signing key generated from today's scope string...
     signing_key = string("AWS4", creds.secret_key)
     for element in scope

--- a/test/aws/awscore_test.yml
+++ b/test/aws/awscore_test.yml
@@ -22,3 +22,74 @@ Resources:
               - cloudformation:DescribeStacks
             Resource:
               - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*
+
+  # Policies to support testing on AWSS3 and AWSSQS
+  S3TestPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allow access to stack outputs
+      Users:
+        - !Sub ${PublicCIUser}
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - s3:ListAllMyBuckets
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - s3:GetBucketPolicyStatus
+              - s3:ListBucketByTags
+              - s3:GetBucketTagging
+              - s3:PutBucketTagging
+              - s3:ListBucketVersions
+              - s3:CreateBucket
+              - s3:ListBucket
+              - s3:GetBucketVersioning
+              - s3:DeleteBucket
+              - s3:PutBucketVersioning
+            Resource:
+              - arn:aws:s3:::ocaws.jl.test.*
+          - Effect: Allow
+            Action:
+              - s3:DeleteObjectTagging
+              - s3:PutObject
+              - s3:GetObject
+              - s3:DeleteObjectVersion
+              - s3:GetObjectVersionTagging
+              - s3:PutObjectVersionTagging
+              - s3:GetObjectTagging
+              - s3:PutObjectTagging
+              - s3:DeleteObjectVersionTagging
+              - s3:DeleteObject
+              - s3:GetObjectVersion
+            Resource:
+              - arn:aws:s3:::ocaws.jl.test.*/*
+  SQSTestPolicy:
+    Type: AWS::IAM::ManagedPolicy
+    Properties:
+      Description: Allow access to stack outputs
+      Users:
+        - !Sub ${PublicCIUser}
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - sqs:ListQueues
+            Resource: "*"
+          - Effect: Allow
+            Action:
+              - sqs:GetQueueAttributes
+              - sqs:GetQueueUrl
+              - sqs:ReceiveMessage
+              - sqs:CreateQueue
+              - sqs:DeleteMessage
+              - sqs:DeleteMessageBatch
+              - sqs:DeleteQueue
+              - sqs:SendMessage
+              - sqs:SendMessageBatch
+              - sqs:SetQueueAttributes
+            Resource:
+              - !Sub arn:aws:sqs:*:${AWS::AccountId}:ocaws-jl-test-queue-*

--- a/test/aws/awscore_test.yml
+++ b/test/aws/awscore_test.yml
@@ -25,9 +25,9 @@ Resources:
 
   # Policies to support testing on AWSS3 and AWSSQS
   S3TestPolicy:
-    Type: AWS::IAM::ManagedPolicy
+    Type: AWS::IAM::Policy
     Properties:
-      Description: Allow access to stack outputs
+      PolicyName: S3TestPolicy
       Users:
         - !Sub ${PublicCIUser}
       PolicyDocument:
@@ -67,9 +67,9 @@ Resources:
             Resource:
               - arn:aws:s3:::ocaws.jl.test.*/*
   SQSTestPolicy:
-    Type: AWS::IAM::ManagedPolicy
+    Type: AWS::IAM::Policy
     Properties:
-      Description: Allow access to stack outputs
+      PolicyName: SQSTestPolicy
       Users:
         - !Sub ${PublicCIUser}
       PolicyDocument:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -123,7 +123,7 @@ end
 
                 # Check credentials load
                 config = AWSCore.aws_config()
-                creds = get_credentials(config[:creds])
+                creds = config[:creds]
 
                 @test creds.access_key_id == "TEST_ACCESS_ID"
                 @test creds.secret_key == "TEST_ACCESS_KEY"
@@ -131,16 +131,14 @@ end
                 # Check credentials refresh
                 ENV["AWS_DEFAULT_PROFILE"] = "test"
                 config = AWSCore.aws_config(
-                    creds = RenewableAWSCredentials(
-                        AWSCredentials(
+                    creds = AWSCredentials(
                             "EXPIRED_ACCESS_ID",
                             "EXPIRED_ACCESS_KEY",
                             expiry = now(UTC),
-                        ),
-                        AWSCore.dot_aws_credentials,
+                            renew = AWSCore.dot_aws_credentials,
                     )
                 )
-                creds = get_credentials(config[:creds])
+                creds = check_credentials(config[:creds])
 
                 @test creds.access_key_id == "TEST_ACCESS_ID"
                 @test creds.secret_key == "TEST_ACCESS_KEY"
@@ -149,7 +147,7 @@ end
                 # Check credential file takes precedence over config
                 ENV["AWS_DEFAULT_PROFILE"] = "test2"
                 config = AWSCore.aws_config()
-                creds = get_credentials(config[:creds])
+                creds = config[:creds]
 
                 @test creds.access_key_id == "RIGHT_ACCESS_ID2"
                 @test creds.secret_key == "RIGHT_ACCESS_KEY2"
@@ -157,14 +155,14 @@ end
                 # Check credentials take precedence over role
                 ENV["AWS_DEFAULT_PROFILE"] = "test3"
                 config = AWSCore.aws_config()
-                creds = get_credentials(config[:creds])
+                creds = config[:creds]
 
                 @test creds.access_key_id == "RIGHT_ACCESS_ID3"
                 @test creds.secret_key == "RIGHT_ACCESS_KEY3"
 
                 ENV["AWS_DEFAULT_PROFILE"] = "test4"
                 config = AWSCore.aws_config()
-                creds = get_credentials(config[:creds])
+                creds = config[:creds]
 
                 @test creds.access_key_id == "RIGHT_ACCESS_ID4"
                 @test creds.secret_key == "RIGHT_ACCESS_KEY4"


### PR DESCRIPTION
Fixes timestamp format for ec2 and ecr credentials. Also fixes renewal to not overwrite `renew` function.
Solves https://github.com/JuliaCloud/AWSCore.jl/issues/68. 
Also addresses https://github.com/JuliaCloud/AWSCore.jl/issues/70 and the remaining comments from #52 to enable testing.