### PR TITLE
Adds possibility for unsigned requests

### DIFF
--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -399,8 +399,8 @@ function do_request(r::AWSRequest)
         r[:headers]["User-Agent"] = "AWSCore.jl/0.0.0"
         r[:headers]["Host"]       = HTTP.URI(r[:url]).host
 
-        # Use credentials to sign request...
-        sign!(r)
+        # If existing, use credentials to sign request...
+        r[:creds] === nothing || sign!(r)
 
         if debug_level > 0
             dump_aws_request(r)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -21,6 +21,42 @@ AWSCore.set_debug_level(1)
 
 aws = aws_config()
 
+@testset "NoAuth" begin
+    pub_request1 = Dict{Symbol, Any}(
+    :service => "s3",
+    :headers => Dict{String, String}("Range" => "bytes=0-0"),
+    :content => "",
+    :resource => "/invenia-static-website-content/invenia_ca/index.html",
+    :url => "https://s3.us-east-1.amazonaws.com/invenia-static-website-content/invenia_ca/index.html",
+    :verb => "GET",
+    :region => "us-east-1",
+    :creds => nothing,
+    )
+    pub_request2 = Dict{Symbol, Any}(
+    :service => "s3",
+    :headers => Dict{String, String}("Range" => "bytes=0-0"),
+    :content => "",
+    :resource => "ryft-public-sample-data/AWS-x86-AMI-queries.json",
+    :url => "https://s3.amazonaws.com/ryft-public-sample-data/AWS-x86-AMI-queries.json",
+    :verb => "GET",
+    :region => "us-east-1",
+    :creds => nothing,
+    )
+    response = nothing
+    try
+        response = AWSCore.do_request(pub_request1)
+    catch e
+        println(e)
+        @test ecode(e) in ["AccessDenied", "NoSuchEntity"]
+        try
+            response = AWSCore.do_request(pub_request2)
+        catch e
+            println(e)
+            @test ecode(e) in ["AccessDenied", "NoSuchEntity"]
+        end
+    end
+    @test response == "<" || response == UInt8['[']
+end
 @testset "Load Credentials" begin
     user = aws_user_arn(aws)
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -23,24 +23,24 @@ aws = aws_config()
 
 @testset "NoAuth" begin
     pub_request1 = Dict{Symbol, Any}(
-    :service => "s3",
-    :headers => Dict{String, String}("Range" => "bytes=0-0"),
-    :content => "",
-    :resource => "/invenia-static-website-content/invenia_ca/index.html",
-    :url => "https://s3.us-east-1.amazonaws.com/invenia-static-website-content/invenia_ca/index.html",
-    :verb => "GET",
-    :region => "us-east-1",
-    :creds => nothing,
+        :service => "s3",
+        :headers => Dict{String, String}("Range" => "bytes=0-0"),
+        :content => "",
+        :resource => "/invenia-static-website-content/invenia_ca/index.html",
+        :url => "https://s3.us-east-1.amazonaws.com/invenia-static-website-content/invenia_ca/index.html",
+        :verb => "GET",
+        :region => "us-east-1",
+        :creds => nothing,
     )
     pub_request2 = Dict{Symbol, Any}(
-    :service => "s3",
-    :headers => Dict{String, String}("Range" => "bytes=0-0"),
-    :content => "",
-    :resource => "ryft-public-sample-data/AWS-x86-AMI-queries.json",
-    :url => "https://s3.amazonaws.com/ryft-public-sample-data/AWS-x86-AMI-queries.json",
-    :verb => "GET",
-    :region => "us-east-1",
-    :creds => nothing,
+        :service => "s3",
+        :headers => Dict{String, String}("Range" => "bytes=0-0"),
+        :content => "",
+        :resource => "ryft-public-sample-data/AWS-x86-AMI-queries.json",
+        :url => "https://s3.amazonaws.com/ryft-public-sample-data/AWS-x86-AMI-queries.json",
+        :verb => "GET",
+        :region => "us-east-1",
+        :creds => nothing,
     )
     response = nothing
     try


### PR DESCRIPTION
This small check allows the user to specify `aws_config(creds=nothing,...)` to do an anonymous request