### PR TITLE
Allow Passing Through HTTP Connection Settings

### DIFF
--- a/src/http.jl
+++ b/src/http.jl
@@ -26,8 +26,8 @@ function http_request(request::AWSRequest)
             push!(options, (:response_stream, io))
         end
 
-        if haskey(request, :http_connection_settings)
-            for v in request[:http_connection_settings]
+        if haskey(request, :http_options)
+            for v in request[:http_options]
                 push!(options, v)
             end
         end

--- a/src/http.jl
+++ b/src/http.jl
@@ -26,6 +26,12 @@ function http_request(request::AWSRequest)
             push!(options, (:response_stream, io))
         end
 
+        if haskey(request, :http_connection_settings)
+            for v in request[:http_connection_settings]
+                push!(options, v)
+            end
+        end
+
         verbose = debug_level - 1
 
         http_stack = HTTP.stack(redirect=false,


### PR DESCRIPTION
aws_config can now take a `:http_connection_settings` key with pairs
like `:connection_limit=>100` to modify the http connection settings.