### PR TITLE
Fix Travis CI failing on AWSException unit test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ Manifest.toml
 docs/build/
 docs/site/
 docs/Manifest.toml
+.idea/*

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSCore"
 uuid = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
-version = "0.6.1"
+version = "0.6.2"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -12,8 +12,6 @@ using Retry
 using XMLDict
 using HTTP
 
-using AWSCore: service_query
-
 AWSCore.set_debug_level(1)
 
 
@@ -563,10 +561,13 @@ end
            "message": "$message"
         }
         """
-    resp = HTTP.Messages.Response(400, body)
-    HTTP.setheader(resp.headers, "Content-Type" => "application/x-amz-json-1.1")
+    headers = ["Content-Type" => "application/x-amz-json-1.1"]
+    status_code = 400
 
-    ex = AWSException(HTTP.StatusError(400, resp))
+    # This does not actually send a request, just creates the object to test with
+    req = HTTP.Request("GET", "https://amazon.ca", headers, body)
+    resp = HTTP.Response(status_code, headers; body=body, request=req)
+    ex = AWSException(HTTP.StatusError(status_code, resp))
 
     @test ex.code == code
     @test ex.message == message
@@ -601,8 +602,3 @@ elseif instance_type == "ECS"
 end
 
 end # testset "AWSCore"
-
-
-#==============================================================================#
-# End of file.
-#==============================================================================#


### PR DESCRIPTION
Notes
---
- Resolves #84 
- [AWSCore.jl Travis CI Failures](https://travis-ci.org/JuliaCloud/AWSCore.jl/builds/580418604)

Problem
---
The `access to undefined reference` is inside of `HTTP.StatusError()`
```
ex = AWSException(HTTP.StatusError(status_code, resp))
```

> https://github.com/JuliaWeb/HTTP.jl/blob/master/src/ExceptionRequest.jl#L45
```
StatusError(status, response::HTTP.Response) = StatusError(status, response.request.method, response.request.target, response)
```

We are defining our `HTTP.Response` as:
```
    code = "InvalidSignatureException"
    message = "Signature expired: ..."
    body = """
        {
           "__type": "$code",
           "message": "$message"
        }
        """
    resp = HTTP.Messages.Response(400, body)
```

When calling the `StatusError()`, we have not defined `resp.request.method` or `resp.request.target` which leads to this error.

Solution
---
To resolve this we need to create a `HTTP.Request` object and include it in the `HTTP.Response` object. In this unit test I just used the same `headers` and `body` for both the `HTTP.Request`/`HTTP.Response` objects as it's just test data.

```
req = HTTP.Request("GET", "http://therainforest.com", headers, body)
resp = HTTP.Response(status_code, headers; body=body, request=req)
ex = AWSException(HTTP.StatusError(status_code, resp))
```