### PR TITLE
Don't include sign.jl twice

### DIFF
--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -378,9 +378,6 @@ function dump_aws_request(r::AWSRequest)
 end
 
 
-include("sign.jl")
-
-
 """
     do_request(::AWSRequest)
 


### PR DESCRIPTION
Was causing this:

```
WARNING: Method definition sign!(Base.Dict{Symbol, Any}) in module AWSCore at /root/.julia/packages/AWSCore/vhwat/src/sign.jl:15 overwritten at /root/.julia/packages/AWSCore/vhwat/src/sign.jl:15.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition sign!(Base.Dict{Symbol, Any}, Any) in module AWSCore at /root/.julia/packages/AWSCore/vhwat/src/sign.jl:15 overwritten at /root/.julia/packages/AWSCore/vhwat/src/sign.jl:15.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition sign_aws2!(Base.Dict{Symbol, Any}, Any) in module AWSCore at /root/.julia/packages/AWSCore/vhwat/src/sign.jl:28 overwritten at /root/.julia/packages/AWSCore/vhwat/src/sign.jl:28.
  ** incremental compilation may be fatally broken for this module **

WARNING: Method definition sign_aws4!(Base.Dict{Symbol, Any}, Any) in module AWSCore at /root/.julia/packages/AWSCore/vhwat/src/sign.jl:67 overwritten at /root/.julia/packages/AWSCore/vhwat/src/sign.jl:67.
  ** incremental compilation may be fatally broken for this module **
```