### PR TITLE
Always return response headers when kwarg is passed

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSCore"
 uuid = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
-version = "0.6.10"
+version = "0.6.11"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -555,7 +555,7 @@ function do_request(r::AWSRequest; return_headers=false)
     end
 
     # Return raw data by default...
-    return (return_headers ? (response.body, Dict(response.headers)) : response.body)
+    return (return_headers ? (response.body, response.headers) : response.body)
 end
 
 

--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -555,7 +555,7 @@ function do_request(r::AWSRequest; return_headers=false)
     end
 
     # Return raw data by default...
-    return (return_headers ? (response.body, nothing) : response.body)
+    return (return_headers ? (response.body, Dict(response.headers)) : response.body)
 end
 
 


### PR DESCRIPTION
Not sure why I missed this, we always want to give back the `response.headers`, not `nothing`.