### PR TITLE
Revert "Preface header call with HTTP"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSCore"
 uuid = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
-version = "0.6.13"
+version = "0.6.12"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -471,11 +471,11 @@ function do_request(r::AWSRequest; return_headers=false)
 
         # Handle BadDigest error and CRC32 thing
         @retry if e isa AWSException && (
-            HTTP.header(e.cause, "crc32body") == "x-amz-crc32" ||
+            header(e.cause, "crc32body") == "x-amz-crc32" ||
             ecode(e) in ("BadDigest", "RequestTimeout", "RequestTimeoutException")
         )
             if debug_level > 1
-                cause = if HTTP.header(e.cause, "crc32body") == "x-amz-crc32"
+                cause = if header(e.cause, "crc32body") == "x-amz-crc32"
                     "CRC32"
                 else
                     ecode(e)


### PR DESCRIPTION
Reverts JuliaCloud/AWSCore.jl#120

From @ianshmean on the [Julia Slack](https://julialang.slack.com/archives/C91DJB2K1/p1590704506002100):
```
julia> awsconf = aws_config(region = "us-east-1")
julia> ec2(awsconf, "StartInstances",  "InstanceId.1" => instanceid)
MethodError: no method matching header(::HTTP.ExceptionRequest.StatusError, ::String)
Closest candidates are:
  header(!Matched::HTTP.Messages.Message, ::Any) at /Users/ian/.julia/packages/HTTP/BOJmV/src/Messages.jl:310
  header(!Matched::HTTP.Messages.Message, ::Any, !Matched::Any) at /Users/ian/.julia/packages/HTTP/BOJmV/src/Messages.jl:310
  header(!Matched::Array{Pair{SubString{String},SubString{String}},1}, ::AbstractString) at /Users/ian/.julia/packages/HTTP/BOJmV/src/Messages.jl:311
  ...
macro expansion at repeat_try.jl:473 [inlined]
do_request(::Dict{Symbol,Any}; return_headers::Bool) at AWSCore.jl:394
do_request at AWSCore.jl:391 [inlined]
service_query(::Dict{Symbol,Any}; args::Base.Iterators.Pairs{Symbol,Any,NTuple{4,Symbol},NamedTuple{(:service, :version, :operation, :args),Tuple{String,String,String,Dict{String,String}}}}) at AWSCore.jl:249
service_query at AWSCore.jl:228 [inlined]
ec2(::Dict{Symbol,Any}, ::String, ::Dict{String,String}) at Services.jl:993
top-level scope at aws.jl:13
```

Our custom `header` method was necessary for error handling. 