### PR TITLE
Kwargs can use underscores and get translated properly in RestXML calls

### DIFF
--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -330,7 +330,9 @@ function service_rest_xml(aws::AWSConfig; args...)
 
     request[:resource] = rest_resource(request, args)
 
-    query_str  = HTTP.escapeuri(args)
+    query_str = HTTP.escapeuri(args)
+    # Convert out arg name to match the AWS hyphen style
+    query_str = replace(query_str, "_"=>"-")
 
     if query_str  != ""
         if occursin("?", request[:resource])


### PR DESCRIPTION
Resolves: https://github.com/JuliaCloud/AWSSDK.jl/issues/16

When passing parameters to AWS requests they need to be specified with a hyphen, for example `continuation-token`:

```
s3req = AWSSDK.S3.list_objects_v2(
    aws,
    Bucket=bucket,
    prefix=prefix,
    continuation-token=string(s3req["NextContinuationToken"]),
)
```

However this is not valid Julia syntax, the current work around is to wrap these kwargs with `var` such as:

```
s3req = AWSSDK.S3.list_objects_v2(
    aws,
    Bucket=bucket,
    prefix=prefix,
    var"continuation-token"=string(s3req["NextContinuationToken"]),
)
```

This adds bulk to calls, and is not inherently obvious. Instead we can use the `_` inbetween words, and translate this to a hyphen in the query string for REST XML calls. Another possible solution would be to use camel case, however this adds a larger complexity.

With these changes you can now do the following:
```
s3req = AWSSDK.S3.list_objects_v2(
    aws,
    Bucket=bucket,
    prefix=prefix,
    continuation_token=string(s3req["NextContinuationToken"]),
)
```