### PR TITLE
Added special casing for AWS Glacier

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -15,6 +15,7 @@ OrderedCollections = "bac558e1-5e72-5ebc-8fee-abe8a469f55d"
 Retry = "20febd7b-183b-5ae2-ac4a-720e7ce64774"
 Sockets = "6462fe0b-24de-5631-8697-dd941f90decc"
 SymDict = "2da68c74-98d7-5633-99d6-8493888d7b1e"
+UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 XMLDict = "228000da-037f-5747-90a9-8195ccbf91a5"
 
 [compat]

--- a/src/Services.jl
+++ b/src/Services.jl
@@ -1385,11 +1385,19 @@ gamelift(operation, args=[]) =
 gamelift(a...; b...) = gamelift(a..., b)
 
 function glacier(aws::AWSConfig, verb, resource, args=[])
+    version = "2012-06-01"
+    glacier_version_header = ["x-amz-glacier-version"=>version]
+
+    if args isa Pair && args.first == "headers"
+        append!(args[2], glacier_version_header)
+    else
+        args = vcat(args, ("headers" => glacier_version_header))
+    end
 
     AWSCore.service_rest_json(
         aws;
         service      = "glacier",
-        version      = "2012-06-01",
+        version      = version,
         verb         = verb,
         resource     = resource,
         args         = args)

--- a/src/Services.jl
+++ b/src/Services.jl
@@ -1386,12 +1386,14 @@ gamelift(a...; b...) = gamelift(a..., b)
 
 function glacier(aws::AWSConfig, verb, resource, args=[])
     version = "2012-06-01"
-    glacier_version_header = ["x-amz-glacier-version"=>version]
+    glacier_version_header = Dict("headers"=>Dict("x-amz-glacier-version"=>version))
 
-    if args isa Pair && args.first == "headers"
-        append!(args[2], glacier_version_header)
+    args = Dict(args)
+
+    if haskey(args, "headers")
+        args["headers"] = merge(+, args["headers"], glacier_version_header["headers"])
     else
-        args = vcat(args, ("headers" => glacier_version_header))
+        args = merge(args, glacier_version_header)
     end
 
     AWSCore.service_rest_json(

--- a/src/Services.jl
+++ b/src/Services.jl
@@ -1386,14 +1386,14 @@ gamelift(a...; b...) = gamelift(a..., b)
 
 function glacier(aws::AWSConfig, verb, resource, args=[])
     version = "2012-06-01"
-    glacier_version_header = Dict("headers"=>Dict("x-amz-glacier-version"=>version))
+    glacier_version_header = Dict("x-amz-glacier-version"=>version)
 
-    args = Dict(args)
+    args = Dict{String, Any}(args)
 
     if haskey(args, "headers")
-        args["headers"] = merge(+, args["headers"], glacier_version_header["headers"])
+        args["headers"] = merge!(Dict(args["headers"]), glacier_version_header)
     else
-        args = merge(args, glacier_version_header)
+        args["headers"] = glacier_version_header
     end
 
     AWSCore.service_rest_json(

--- a/test/aws/awscore_test.yml
+++ b/test/aws/awscore_test.yml
@@ -23,7 +23,40 @@ Resources:
             Resource:
               - !Sub arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/${AWS::StackName}/*
 
-  # Policies to support testing on AWSS3 and AWSSQS
+  # Policies to support testing on Glacier, Route53, S3, and SQS
+  GlacierTestPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: GlacierTestPolicy
+      Users:
+        - !Sub ${PublicCIUser}
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - glacier:CreateVault
+              - glacier:DeleteVault
+            Resource:
+              - !Sub arn:aws:glacier:*:${AWS::AccountId}:vaults/test-vault-*
+          - Effect: Allow
+            Action:
+              - glacier:ListVaults
+            Resource:
+              - "*"
+  Route53TestPolicy:
+    Type: AWS::IAM::Policy
+    Properties:
+      PolicyName: Route53TestPolicy
+      Users:
+        - !Sub ${PublicCIUser}
+      PolicyDocument:
+        Version: 2012-10-17
+        Statement:
+          - Effect: Allow
+            Action:
+              - route53:GetAccountLimit
+            Resource: "*"
   S3TestPolicy:
     Type: AWS::IAM::Policy
     Properties:

--- a/test/endpoints.jl
+++ b/test/endpoints.jl
@@ -10,3 +10,39 @@ using AWSCore.Services: route53
         end
     end
 end
+
+
+@testset "rest-json" begin
+    @testset "glacier - special case" begin
+        vault_names = ["test-vault-01", "test-vault-02"]
+
+        @testset "Create Vaults" begin
+            for vault in vault_names
+                Services.glacier("PUT", "/-/vaults/$vault")
+            end
+        end
+
+        @testset "Get Vaults" begin
+            # If this is an Integer AWS Coral cannot convert it to a String
+            # "class com.amazon.coral.value.json.numbers.TruncatingBigNumber can not be converted to an String"
+            limit = "1"
+
+            result = Services.glacier("GET", "/-/vaults", ("limit"=>limit))
+            @test length(result["VaultList"]) == parse(Int, limit)
+        end
+
+        @testset "Delete Vaults" begin
+            for vault in vault_names
+                Services.glacier("DELETE", "/-/vaults/$vault")
+            end
+
+            result = Services.glacier("GET", "/-/vaults")
+
+            vault_names = [v["VaultName"] for v in result["VaultList"]]
+
+            for vault in vault_names
+                @test !(vault in vault_names)
+            end
+        end
+    end
+end

--- a/test/endpoints.jl
+++ b/test/endpoints.jl
@@ -26,9 +26,22 @@ end
             # If this is an Integer AWS Coral cannot convert it to a String
             # "class com.amazon.coral.value.json.numbers.TruncatingBigNumber can not be converted to an String"
             limit = "1"
+            headers = Dict("foo"=>"bar")
 
-            result = Services.glacier("GET", "/-/vaults", ("limit"=>limit))
-            @test length(result["VaultList"]) == parse(Int, limit)
+            cases = [
+                Dict("limit"=>limit, "headers"=>Dict("foo"=>"bar")),
+                Dict("limit"=>limit),
+                ("limit"=>limit, "headers"=>Dict("foo"=>"bar")),
+                ("limit"=>limit),
+                [("limit"=>limit), ("headers"=>Dict("foo"=>"bar"))],
+                [("limit"=>limit)]
+            ]
+
+            @testset "$case" for case in cases
+                result = Services.glacier("GET", "/-/vaults", case)
+
+                @test length(result["VaultList"]) == parse(Int, limit)
+            end
         end
 
         @testset "Delete Vaults" begin
@@ -37,11 +50,10 @@ end
             end
 
             result = Services.glacier("GET", "/-/vaults")
-
-            vault_names = [v["VaultName"] for v in result["VaultList"]]
+            vaults = [v["VaultName"] for v in result["VaultList"]]
 
             for vault in vault_names
-                @test !(vault in vault_names)
+                @test !(vault in vaults)
             end
         end
     end

--- a/test/endpoints.jl
+++ b/test/endpoints.jl
@@ -14,7 +14,7 @@ end
 
 @testset "rest-json" begin
     @testset "glacier - special case" begin
-        vault_names = ["test-vault-01", "test-vault-02"]
+        vault_names = [string("test-vault-", UUIDs.uuid4()), string("test-vault-", UUIDs.uuid4())]
 
         @testset "Create Vaults" begin
             for vault in vault_names

--- a/test/endpoints.jl
+++ b/test/endpoints.jl
@@ -30,10 +30,16 @@ end
 
             cases = [
                 Dict("limit"=>limit, "headers"=>Dict("foo"=>"bar")),
+                Dict("limit"=>limit, "headers"=>("foo"=>"bar")),
+                Dict("limit"=>limit, "headers"=>[("foo"=>"bar"), ("biz"=>"baz")]),
                 Dict("limit"=>limit),
                 ("limit"=>limit, "headers"=>Dict("foo"=>"bar")),
+                ("limit"=>limit, "headers"=>("foo"=>"bar")),
+                ("limit"=>limit, "headers"=>[("foo"=>"bar"), ("biz"=>"baz")]),
                 ("limit"=>limit),
                 [("limit"=>limit), ("headers"=>Dict("foo"=>"bar"))],
+                [("limit"=>limit), ("headers"=>("foo"=>"bar"))],
+                [("limit"=>limit), ("headers"=>[("foo"=>"bar"), ("biz"=>"baz")])],
                 [("limit"=>limit)]
             ]
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -5,6 +5,7 @@
 #==============================================================================#
 
 using AWSCore
+using AWSCore: Services
 using Dates
 using HTTP
 using HTTP: Headers, URI

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,7 @@ using Mocking
 using Retry
 using SymDict
 using Test
+using UUIDs
 using XMLDict
 using .SignatureV4
 


### PR DESCRIPTION
**NOTE: About 5 months ago I had made changes to the CI user to include GETs on Route53, I only realized this mistake now which is why that policy is bundled together here.**

## Problem
Currently any requests to AWS Glacier are failing. This is because it requires its API Version to be placed in the `x-amz-glacier-version` header, opposed to other services which want this value in `version`.

Other projects which have had this issue: [Swift AWS](https://github.com/swift-aws/aws-sdk-swift/issues/98), [Clojure AWS API](https://github.com/cognitect-labs/aws-api/issues/74)

Below is an example of the current state:
```julia
using AWSCore.Services
Services.glacier("GET", "/-/vaults")

HTTP.ExceptionRequest.StatusError(400, "GET", "/-/vaults", HTTP.Messages.Response:
"""
HTTP/1.1 400 Bad Request
x-amzn-RequestId: -J5ZjGzLNqL6lYuiyhjHMI0fYUWQ24tvFvZfUAqPUcQTlVI
Content-Length: 109
Date: Fri, 19 Jun 2020 17:44:07 GMT
Connection: close

{"code":"MissingParameterValueException","message":"Required parameter missing: API version","type":"Client"}""")
```

## Solution
I am modifying the `Services.glacier()` to add the `x-amz-glacier-version` header, instead of special casing in the `service_rest_json()`.

## Notes
Modifying the `Service.jl` file is improper as this file is autogenerated. However, the generation of this file is a manual process and as far as I am aware broken. Since I am working on archiving this package in favour of [AWS.jl](https://github.com/JuliaCloud/AWS.jl), I think directly modifying this file is an okay solution.

I spent some time, but could not come up with a better solution for adding in the glacier version header. There are two cases here to look at:

1) `args` do not contain a `headers` when passed in, and we want to add to this:

```julia
glacier("GET", "/-/vaults", ("limit"=>"1"))
```

2) `args` does contain `headers` when passed in, and we want to append to this:

```julia
glacier("GET", "/-/vaults", ("headers"=>["a"=>"b"]))
```

If anyone has a better solution, I'd love to hear!