### PR TITLE
added some documentation for AWSConfig

### DIFF
--- a/src/AWSCore.jl
+++ b/src/AWSCore.jl
@@ -30,6 +30,11 @@ This dictionary holds [`RenewableAWSCredentials`](@ref) and AWS region configura
 ```julia
 aws = AWSConfig(:creds => RenewableAWSCredentials(), :region => "us-east-1")`
 ```
+
+Available keys are
+- `:creds`: `AWSCredentials` object as retruned by `AWSCredentials()`.
+- `:region`: String giving the region, e.g. `"us-east-1"`.
+- `:endpoint`: AWS host URL to use.
 """
 const AWSConfig = SymbolDict
 


### PR DESCRIPTION
I needed to hack the request URL for using a local instance of min.io, and I was afriad I would have to change a bunch of stuff support that, but I was happy to discover that this functionality is already supported, at least in AWSS3.jl.

I've added some documentation to the string to make this slightly easier to discover.

Note that I'm not actually 100% sure that every service supports this.  The functionality that was actually relevant to me was a check for `:endpoint` in AWSS3.jl, so at this point there would seem to be nothing AWSCore that provides this for services in a generic way.

If there are more available options that I'm unaware of, please let me know and I'll add to this string, thanks!