### PR TITLE
do not consider empty env vars for AWSCredentials

### DIFF
--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -365,13 +365,17 @@ to create AWSCredentials.
 """
 function env_var_credentials()
     if haskey(ENV, "AWS_ACCESS_KEY_ID") && haskey(ENV, "AWS_SECRET_ACCESS_KEY")
-        return AWSCredentials(
-            ENV["AWS_ACCESS_KEY_ID"],
-            ENV["AWS_SECRET_ACCESS_KEY"],
-            get(ENV, "AWS_SESSION_TOKEN", ""),
-            get(ENV, "AWS_USER_ARN", "");
-            renew=env_var_credentials
-        )
+        aws_access_key_id = ENV["AWS_ACCESS_KEY_ID"]
+        aws_secret_access_key = ENV["AWS_SECRET_ACCESS_KEY"]
+        if !isempty(aws_access_key_id) && !isempty(aws_secret_access_key)
+            return AWSCredentials(
+                aws_access_key_id,
+                aws_secret_access_key,
+                get(ENV, "AWS_SESSION_TOKEN", ""),
+                get(ENV, "AWS_USER_ARN", "");
+                renew=env_var_credentials
+            )
+        end
     end
 
     return nothing

--- a/test/credentials.jl
+++ b/test/credentials.jl
@@ -474,6 +474,13 @@ end
             @test aws_creds.access_key_id == test_values["AccessKeyId"]
             @test aws_creds.secret_key == test_values["SecretAccessKey"]
         end
+
+        withenv(
+            "AWS_ACCESS_KEY_ID" => "",
+            "AWS_SECRET_ACCESS_KEY" => ""
+        ) do
+            @test env_var_credentials() === nothing
+        end
     end
 
     @testset "Instance - EC2" begin


### PR DESCRIPTION
Check if environment variables `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` are not empty before considering them to create an AWSCredentials instance.

fixes #130