### PR TITLE
Treat 'RoleArn' as an optional field when fetching ECS credentials

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "AWSCore"
 uuid = "4f1ea46c-232b-54a6-9b17-cc2d0f3e6598"
-version = "0.6.17"
+version = "0.6.18"
 
 [deps]
 Base64 = "2a0f44e3-6c83-55bd-87e4-b1978d98bd5f"

--- a/src/AWSCredentials.jl
+++ b/src/AWSCredentials.jl
@@ -350,7 +350,8 @@ function ecs_instance_credentials()
         new_creds["AccessKeyId"],
         new_creds["SecretAccessKey"],
         new_creds["Token"],
-        new_creds["RoleArn"];
+        # The RoleArn field may not be present for Amazon SageMaker jobs
+        get(new_creds, "RoleArn", "");
         expiry=expiry,
         renew=ecs_instance_credentials
     )


### PR DESCRIPTION
The [ECS developers guide](https://docs.aws.amazon.com/AmazonECS/latest/developerguide/task-iam-roles.html) implies that the `RoleArn` field should always be returned when querying the container's credential endpoint, however this isn't always the case for Amazon SageMaker jobs.

Amazon avoids this in [botocore](https://github.com/boto/botocore/blob/21b06efb39da61fe4101ab9709140dc1e51dc33d/botocore/credentials.py#L1886-L1889) by not accessing the `RoleArn` field.